### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-deno-release.yml
+++ b/.github/workflows/check-deno-release.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 */12 * * *' # every 12 hours
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   check_new_deno:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/thomas3577/DenoHost/security/code-scanning/1](https://github.com/thomas3577/DenoHost/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow. Start by granting the minimal permissions required for the workflow to function. Based on the described steps, the workflow needs to read repository content to fetch tags and write permission to create and push new tags. The appropriate permissions for this workflow are `contents: write`, which includes both read and write access to repository content. This should be applied at the root level of the workflow to cover all jobs, ensuring consistency.

Changes will be made to the `.github/workflows/check-deno-release.yml` file to include the `permissions` block at the root level of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
