### PR TITLE
Release/safety gates alpha stable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
             TAG_NAME="${GITHUB_REF#refs/tags/}"
             PACKAGE_VERSION="${TAG_NAME#v}"
 
-            # Check if this is a prerelease based on tag name
+            # Any semver suffix indicates prerelease (e.g. -alpha.1, -hotfix.1)
             IS_PRERELEASE="false"
-            if [[ "$TAG_NAME" =~ -(alpha|beta|rc|preview)\. ]]; then
+            if [[ "$TAG_NAME" == *-* ]]; then
               IS_PRERELEASE="true"
               echo "Detected prerelease tag: $TAG_NAME"
             fi
@@ -113,6 +113,47 @@ jobs:
 
       - name: Lint (dotnet format)
         run: dotnet format DenoHost.sln --verify-no-changes --severity warn
+
+  tag-validation:
+    name: Validate Stable Tag Source
+    needs: get-version
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify stable tag has matching alpha.1 on same commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_NAME="${GITHUB_REF#refs/tags/v}"
+
+          if [[ "$TAG_NAME" == *-* ]]; then
+            echo "Prerelease tag detected: v$TAG_NAME. Skipping stable alpha gate."
+            exit 0
+          fi
+
+          ALPHA_TAG="v${TAG_NAME}-alpha.1"
+          git fetch --tags --force
+
+          if ! git rev-parse "$ALPHA_TAG" >/dev/null 2>&1; then
+            echo "::error::Stable release v$TAG_NAME requires prerelease tag $ALPHA_TAG on the same commit."
+            exit 1
+          fi
+
+          ALPHA_SHA="$(git rev-list -n 1 "$ALPHA_TAG")"
+          STABLE_SHA="$(git rev-list -n 1 "$GITHUB_REF")"
+
+          if [[ "$ALPHA_SHA" != "$STABLE_SHA" ]]; then
+            echo "::error::Stable tag v$TAG_NAME must point to the same commit as $ALPHA_TAG."
+            echo "::error::alpha sha:  $ALPHA_SHA"
+            echo "::error::stable sha: $STABLE_SHA"
+            exit 1
+          fi
+
+          echo "Stable tag v$TAG_NAME is valid: matching alpha tag $ALPHA_TAG found on same commit."
 
   build-runtime:
     name: Build Runtime Packages
@@ -297,9 +338,69 @@ jobs:
       - name: Run Unit Tests
         run: dotnet test DenoHost.Tests/DenoHost.Tests.csproj -c Release -r linux-x64 --no-build
 
+  smoke-test-packaged:
+    name: Smoke Test Packaged Runtime
+    needs: [get-version, build-core, build-runtime]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Download Core Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: DenoHost.Core.${{ needs.get-version.outputs.package_version }}
+          path: ./nupkg/core
+
+      - name: Download Linux Runtime Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: DenoHost.Runtime.linux-x64.${{ needs.get-version.outputs.package_version }}
+          path: ./nupkg/runtime/linux-x64
+
+      - name: Verify bypass is not enabled
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${DENOHOST_ALLOW_CHECKSUM_BYPASS:-}" ]]; then
+            echo "::error::DENOHOST_ALLOW_CHECKSUM_BYPASS must not be set during release smoke tests."
+            exit 1
+          fi
+
+      - name: Create smoke test project and restore local packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf ./smoke-release
+          dotnet new console -n smoke-release -f net9.0
+          cd smoke-release
+          dotnet nuget add source ../nupkg/core --name local-core
+          dotnet nuget add source ../nupkg/runtime/linux-x64 --name local-runtime
+          dotnet add package DenoHost.Core --version "${{ needs.get-version.outputs.package_version }}" --source local-core
+          dotnet add package DenoHost.Runtime.linux-x64 --version "${{ needs.get-version.outputs.package_version }}" --source local-runtime
+
+      - name: Run runtime smoke test without checksum bypass
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd smoke-release
+          cat > Program.cs <<'EOF'
+          using DenoHost.Core;
+
+          var result = await Deno.Execute<string>("eval", new[] { "console.log('smoke-ok')" });
+          Console.WriteLine(result);
+          EOF
+          env -u DENOHOST_ALLOW_CHECKSUM_BYPASS dotnet run
+
   publish-runtime:
     name: Publish Runtime NuGet
-    needs: [get-version, build-runtime, test-on-linux, test-on-windows]
+    needs: [get-version, tag-validation, build-runtime, smoke-test-packaged, test-on-linux, test-on-windows]
     if: startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
@@ -313,6 +414,15 @@ jobs:
           name: DenoHost.Runtime.${{ matrix.rid }}.${{ needs.get-version.outputs.package_version }}
           path: ./nupkg/runtime/${{ matrix.rid }}
 
+      - name: Ensure checksum bypass is disabled for publish
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${DENOHOST_ALLOW_CHECKSUM_BYPASS:-}" ]]; then
+            echo "::error::DENOHOST_ALLOW_CHECKSUM_BYPASS must not be set during publish."
+            exit 1
+          fi
+
       - name: Push Runtime Package to NuGet
         run: dotnet nuget push ./nupkg/runtime/${{ matrix.rid }}/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
 
@@ -321,7 +431,7 @@ jobs:
 
   publish-core:
     name: Publish Core NuGet
-    needs: [get-version, build-core, test-on-linux, test-on-windows]
+    needs: [get-version, tag-validation, build-core, smoke-test-packaged, test-on-linux, test-on-windows]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
@@ -329,6 +439,15 @@ jobs:
         with:
           name: DenoHost.Core.${{ needs.get-version.outputs.package_version }}
           path: ./nupkg/core
+
+      - name: Ensure checksum bypass is disabled for publish
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${DENOHOST_ALLOW_CHECKSUM_BYPASS:-}" ]]; then
+            echo "::error::DENOHOST_ALLOW_CHECKSUM_BYPASS must not be set during publish."
+            exit 1
+          fi
 
       - name: Push Core Package to NuGet
         run: dotnet nuget push ./nupkg/core/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -395,6 +395,12 @@ jobs:
 
           var result = await Deno.Execute<string>("eval", new[] { "console.log('smoke-ok')" });
           Console.WriteLine(result);
+
+          if (string.IsNullOrWhiteSpace(result) || !result.Contains("smoke-ok", StringComparison.Ordinal))
+          {
+            Console.Error.WriteLine("Smoke test failed: expected output to contain 'smoke-ok'.");
+            Environment.Exit(1);
+          }
           EOF
           env -u DENOHOST_ALLOW_CHECKSUM_BYPASS dotnet run
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,15 @@ jobs:
           if [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9] ]]; then
             # Tagged release
             TAG_NAME="${GITHUB_REF#refs/tags/}"
-            PACKAGE_VERSION="${TAG_NAME#v}"
+            SEMVER_TAG="${TAG_NAME#v}"
+            SEMVER_REGEX='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+
+            if ! [[ "$SEMVER_TAG" =~ $SEMVER_REGEX ]]; then
+              echo "::error::Invalid tag '$TAG_NAME'. Expected format vX.Y.Z or vX.Y.Z-prerelease."
+              exit 1
+            fi
+
+            PACKAGE_VERSION="$SEMVER_TAG"
 
             # Any semver suffix indicates prerelease (e.g. -alpha.1, -hotfix.1)
             IS_PRERELEASE="false"
@@ -129,6 +137,12 @@ jobs:
         run: |
           set -euo pipefail
           TAG_NAME="${GITHUB_REF#refs/tags/v}"
+          SEMVER_REGEX='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+
+          if ! [[ "$TAG_NAME" =~ $SEMVER_REGEX ]]; then
+            echo "::error::Invalid tag 'v$TAG_NAME'. Expected format vX.Y.Z or vX.Y.Z-prerelease."
+            exit 1
+          fi
 
           if [[ "$TAG_NAME" == *-* ]]; then
             echo "Prerelease tag detected: v$TAG_NAME. Skipping stable alpha gate."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ To avoid shipping broken NuGet packages, releases follow strict gates:
 1. Publish `vX.Y.Z-alpha.1` first.
 2. Validate CI, signing checks, and smoke test results for the alpha.
 3. Publish stable `vX.Y.Z` only from the exact same commit as `vX.Y.Z-alpha.1`.
-4. Never publish if runtime validation needs checksum bypass.
+4. Never publish if checksum bypass is enabled.
 5. Runtime and core package publishes must only happen through CI after all gates are green.
 
 ## Need help?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,16 @@ submit pull requests.
 - Add unit tests for new features or bug fixes if possible
 - Clearly describe what and why you changed something in your pull request
 
+## Release Safety Process
+
+To avoid shipping broken NuGet packages, releases follow strict gates:
+
+1. Publish `vX.Y.Z-alpha.1` first.
+2. Validate CI, signing checks, and smoke test results for the alpha.
+3. Publish stable `vX.Y.Z` only from the exact same commit as `vX.Y.Z-alpha.1`.
+4. Never publish if runtime validation needs checksum bypass.
+5. Runtime and core package publishes must only happen through CI after all gates are green.
+
 ## Need help?
 
 If you have any questions, feel free to open an issue!

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ await denoProcess.StopAsync();
 
 Release/package builds must provide `DENOHOST_METADATA_SIGNING_PRIVATE_KEY_PEM`; otherwise the workflow in `.github/workflows/build.yml` fails, and `DenoHost.Runtime.Downloader.DownloaderLogic` throws at runtime instead of silently skipping signing. The bundled verification key is `Config/metadata-signing-public.pem`, which is embedded into `DenoHost.Core`.
 
+### Release Safety Gates
+
+- Stable tags (`vX.Y.Z`) are accepted only when a matching prerelease tag (`vX.Y.Z-alpha.1`) exists on the same commit.
+- Packaged smoke tests must pass before NuGet publish.
+- Release publish is blocked if checksum bypass is enabled.
+
 ### Break-Glass (temporary bypass)
 
 For incident mitigation only, checksum validation can be bypassed by setting:


### PR DESCRIPTION
# Pull Request

**Description**  
This PR adds release safety gates to prevent broken package publishes and hardens smoke-test validation for runtime integrity checks.

Main changes:
- Added stable tag gating: stable tags (`vX.Y.Z`) are only allowed when a matching prerelease tag (`vX.Y.Z-alpha.1`) exists on the same commit.
- Added packaged runtime smoke test before publish, running without checksum bypass.
- Added explicit smoke output assertion (`smoke-ok`) and fail-fast behavior when expected output is missing.
- Strengthened publish gating so NuGet publish depends on validation jobs.
- Updated release safety wording/documentation for consistent terminology.

**Type of change:**

- [x] Bug fix
- [ ] New feature
- [x] Tests/CI
- [x] Documentation
- [ ] Other

**Checklist:**

- [ ] Code builds and tests pass
- [x] Documentation/examples updated (if needed)
- [ ] Related issue referenced (if any): Closes #

**Additional notes**  
- This PR intentionally enforces stricter release controls to avoid publishing invalid runtime/signing combinations.
- Smoke test now fails with non-zero exit if runtime execution output does not contain `smoke-ok`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release validation to ensure stable releases have corresponding prerelease tags
  * Added smoke testing before NuGet package publishing
  * Added safety guards to prevent publishing when checksum bypass is enabled

* **Documentation**
  * Documented release safety process in contributing guide
  * Added release safety gates documentation to README

<!-- end of auto-generated comment: release notes by coderabbit.ai -->