### PR TITLE
fix(ci): use explicit local NuGet paths in smoke test package restore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,8 +418,8 @@ jobs:
           cd smoke-release
           dotnet nuget add source ../nupkg/core --name local-core
           dotnet nuget add source ../nupkg/runtime/linux-x64 --name local-runtime
-          dotnet add package DenoHost.Core --version "${{ needs.get-version.outputs.package_version }}" --source local-core
-          dotnet add package DenoHost.Runtime.linux-x64 --version "${{ needs.get-version.outputs.package_version }}" --source local-runtime
+          dotnet add package DenoHost.Core --version "${{ needs.get-version.outputs.package_version }}" --source ../nupkg/core
+          dotnet add package DenoHost.Runtime.linux-x64 --version "${{ needs.get-version.outputs.package_version }}" --source ../nupkg/runtime/linux-x64
 
       - name: Run runtime smoke test without checksum bypass
         shell: bash


### PR DESCRIPTION
# Pull Request

**Description**  
This PR fixes the packaged runtime smoke test in CI.  
`dotnet add package --source` previously used named NuGet source aliases (`local-core` / `local-runtime`), which were interpreted as local folder paths in the smoke project and caused `NU1301` (`.../smoke-release/local-core` does not exist).  
The workflow now uses explicit local artifact paths for package restore so the smoke test can reliably resolve DenoHost.Core and DenoHost.Runtime.linux-x64.

**Type of change:**

- [x] Bug fix
- [ ] New feature
- [x] Tests/CI
- [ ] Documentation
- [ ] Other

**Checklist:**

- [ ] Code builds and tests pass
- [x] Documentation/examples updated (if needed)
- [ ] Related issue referenced (if any): Closes #

**Additional notes**  
No product code changes; only CI workflow path handling in the smoke-test step.  
Please rely on the current GitHub Actions run for final validation of this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes.** This release contains internal build process improvements to the CI/CD workflow, with modifications to how packages are installed during smoke testing. No impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->