### PR TITLE
fix(ci): restore smoke test packages from local feeds and nuget.org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,8 +418,9 @@ jobs:
           cd smoke-release
           dotnet nuget add source ../nupkg/core --name local-core
           dotnet nuget add source ../nupkg/runtime/linux-x64 --name local-runtime
-          dotnet add package DenoHost.Core --version "${{ needs.get-version.outputs.package_version }}" --source ../nupkg/core
-          dotnet add package DenoHost.Runtime.linux-x64 --version "${{ needs.get-version.outputs.package_version }}" --source ../nupkg/runtime/linux-x64
+          dotnet add package DenoHost.Core --version "${{ needs.get-version.outputs.package_version }}" --no-restore
+          dotnet add package DenoHost.Runtime.linux-x64 --version "${{ needs.get-version.outputs.package_version }}" --no-restore
+          dotnet restore --source ../nupkg/core --source ../nupkg/runtime/linux-x64 --source https://api.nuget.org/v3/index.json
 
       - name: Run runtime smoke test without checksum bypass
         shell: bash


### PR DESCRIPTION
# Pull Request

**Description**  
This PR fixes the packaged runtime smoke test restore flow in CI.

The smoke test previously added local package sources and then restored `DenoHost.Core` in a way that could leave transitive dependencies unresolved from the local feed only. That caused `NU1101` for `Microsoft.Extensions.Logging.Abstractions` during the release smoke test.

This change makes the smoke test:
- add the package references with `--no-restore`
- run an explicit `dotnet restore`
- restore against both local package feeds and `https://api.nuget.org/v3/index.json`

This keeps the smoke test pinned to the locally built packages while still allowing normal NuGet transitive dependencies to resolve correctly.

**Type of change:**

- [x] Bug fix
- [ ] New feature
- [x] Tests/CI
- [ ] Documentation
- [ ] Other

**Checklist:**

- [ ] Code builds and tests pass
- [ ] Documentation/examples updated (if needed)
- [ ] Related issue referenced (if any): Closes #

**Additional notes**  
Local validation confirmed the restore logic change for the `DenoHost.Core` package flow.  
A full local build/test pass could not be completed in this environment because runtime package builds require `DENOHOST_METADATA_SIGNING_PRIVATE_KEY_PEM`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved smoke test package restoration process in CI/CD pipeline by refactoring the package setup workflow to use explicit restoration with local and public package sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->