### PR TITLE
feat(ci): migrate NuGet publishing to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,7 +389,7 @@ jobs:
             10.0.x
 
       - name: Download Linux Runtime Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: DenoHost.Runtime.linux-x64.${{ needs.get-version.outputs.package_version }}
           path: ./nupkg/runtime/linux-x64
@@ -471,7 +471,7 @@ jobs:
 
     steps:
       - name: Download Runtime Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: DenoHost.Runtime.${{ matrix.rid }}.${{ needs.get-version.outputs.package_version }}
           path: ./nupkg/runtime/${{ matrix.rid }}
@@ -502,7 +502,7 @@ jobs:
       id-token: write # Required for NuGet trusted publishing (OIDC)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: DenoHost.Core.${{ needs.get-version.outputs.package_version }}
           path: ./nupkg/core
@@ -552,13 +552,13 @@ jobs:
     steps:
       # Download all artifacts to attach to release
       - name: Download Core Package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: DenoHost.Core.${{ needs.get-version.outputs.package_version }}
           path: ./nupkg/core
 
       - name: Download Runtime Packages
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: DenoHost.Runtime.*.${{ needs.get-version.outputs.package_version }}
           path: ./nupkg/runtime

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -463,6 +463,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
+      id-token: write # Required for NuGet trusted publishing (OIDC)
     strategy:
       matrix:
         rid: [win-x64, win-arm64, linux-x64, linux-arm64, osx-x64, osx-arm64]
@@ -475,8 +476,14 @@ jobs:
           name: DenoHost.Runtime.${{ matrix.rid }}.${{ needs.get-version.outputs.package_version }}
           path: ./nupkg/runtime/${{ matrix.rid }}
 
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push Runtime Package to NuGet
-        run: dotnet nuget push ./nupkg/runtime/${{ matrix.rid }}/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push ./nupkg/runtime/${{ matrix.rid }}/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
 
   publish-core:
     name: Publish Core NuGet
@@ -492,6 +499,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
+      id-token: write # Required for NuGet trusted publishing (OIDC)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
@@ -499,8 +507,14 @@ jobs:
           name: DenoHost.Core.${{ needs.get-version.outputs.package_version }}
           path: ./nupkg/core
 
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push Core Package to NuGet
-        run: dotnet nuget push ./nupkg/core/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push ./nupkg/core/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
 
   verify-alpha-from-nuget:
     name: Verify Alpha Package From NuGet


### PR DESCRIPTION
# Pull Request

**Description**\
Replaces the long-lived NUGET_API_KEY secret with NuGet Trusted Publishing via GitHub Actions OIDC. The publish-runtime and publish-core jobs now use NuGet/login@v1 to exchange a short-lived GitHub OIDC token for a temporary NuGet API key, eliminating the need to store and rotate a static API key.

**Type of change:**

- [ ] Bug fix
- [ ] New feature
- [x] Tests/CI
- [ ] Documentation
- [ ] Other

**Checklist:**

- [ ] Code builds and tests pass
- [ ] Documentation/examples updated (if needed)
- [ ] Related issue referenced (if any): Closes #

**Additional notes**\
Before merging, the following manual steps are required:

1. Create a Trusted Publishing policy on nuget.org (Owner: thomas3577, Repository: DenoHost, Workflow: build.yml)
2. Add a NUGET_USER secret to the GitHub repo (nuget.org profile name, not email)
3. After a successful release, the NUGET_API_KEY secret can be deleted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release publishing to use a more secure authentication method for package uploads.
  * Improved the reliability of package publishing by using temporary access credentials instead of a static secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->