### PR TITLE
chore(deps): group codeql-action dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
# Pull Request

**Description**\
Dependabot treats each `uses:` reference (init, analyze, ...) as a separate dependency, so a codeql-action release triggers multiple PRs. Merging only one leaves init/analyze on mismatched versions and breaks CodeQL. Grouping them ensures they land in a single PR.

**Type of change:**

- [x] Bug fix
- [ ] New feature
- [ ] Tests/CI
- [ ] Documentation
- [ ] Other

**Checklist:**

- [ ] Code builds and tests pass
- [ ] Documentation/examples updated (if needed)
- [ ] Related issue referenced (if any): Closes #

**Additional notes**\
(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to group related CodeQL action updates together, helping keep maintenance changes more organized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->