### PR TITLE
fix(ci): increase NuGet alpha propagation retry budget to ~38 minutes

### DIFF
--- a/.github/actions/verify-alpha-nuget/scripts/wait-nuget-propagation.test.ts
+++ b/.github/actions/verify-alpha-nuget/scripts/wait-nuget-propagation.test.ts
@@ -78,7 +78,7 @@ Deno.test('waitForPackageAvailability fails after exhausting retries', async () 
     'Package DenoHost.Core 2.3.0-alpha.1 did not appear on nuget.org within timeout.',
   );
 
-  assertEquals(sleeps, [10000, 20000, 30000, 45000, 60000, 60000, 60000, 60000, 60000, 60000, 60000, 60000, 60000, 60000, 60000, 60000, 60000, 60000, 60000]);
+  assertEquals(sleeps, [10000, 20000, 30000, 45000, ...Array(35).fill(60000)]);
 });
 
 Deno.test('waitForPackageAvailability retries when fetch throws', async () => {

--- a/.github/actions/verify-alpha-nuget/scripts/wait-nuget-propagation.ts
+++ b/.github/actions/verify-alpha-nuget/scripts/wait-nuget-propagation.ts
@@ -1,5 +1,5 @@
 const DEFAULT_PACKAGES = ['DenoHost.Core', 'DenoHost.Runtime.linux-x64'];
-const MAX_ATTEMPTS = 20;
+const MAX_ATTEMPTS = 40;
 const REQUEST_TIMEOUT_MS = 30_000;
 
 export interface WaitOptions {


### PR DESCRIPTION
# Pull Request

**Description**\
The verify-alpha job failed even though the package was successfully published to nuget.org — this time nuget.org took longer than the previous 17.75-minute budget (20 attempts) to make it visible on the v3-flatcontainer endpoint. Bumped MAX_ATTEMPTS from 20 to 40 to add margin beyond Microsoft's documented worst case (up to 15 minutes under high load).

**Type of change:**

- [x] Bug fix
- [ ] New feature
- [x] Tests/CI
- [ ] Documentation
- [ ] Other

**Checklist:**

- [ ] Code builds and tests pass
- [ ] Documentation/examples updated (if needed)
- [ ] Related issue referenced (if any): Closes #

**Additional notes**\
(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package availability checks by allowing additional time for NuGet package propagation before reporting a failure.

* **Tests**
  * Updated retry validation to reflect the extended polling window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->